### PR TITLE
Correção da Tipagem do Content

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,7 +6,21 @@ import styles from './App.module.css';
 
 import './global.css';
 
-const posts = [
+interface postProps {
+  id: number;
+  author: {
+      avatarUrl: string;
+      name: string;
+      role: string;
+  };
+  content: {
+      type: "paragraph" | "link";
+      content: string;
+  }[];
+  publishedAt: Date;
+}
+
+const posts : postProps[] = [
   {
     id: 1,
     author: {

--- a/src/components/Avatar.tsx
+++ b/src/components/Avatar.tsx
@@ -1,17 +1,15 @@
+import { ImgHTMLAttributes } from "react";
 import styles from './Avatar.module.css'
 
-interface AvatarProps {
+interface AvatarProps extends ImgHTMLAttributes<HTMLImageElement> {
   hasBorder?: boolean;
-  src: string;
-  alt?: string;
 }
 
-export function Avatar({ hasBorder = true, src, alt }: AvatarProps) {
+export function Avatar({ hasBorder = true, ...props}: AvatarProps) {
   return (
     <img
       className={hasBorder ? styles.avatarWithBorder : styles.avatar}
-      src={src}
-      alt={alt}
+      {...props}
     />
   );
 }

--- a/src/components/Comment.tsx
+++ b/src/components/Comment.tsx
@@ -24,7 +24,11 @@ export function Comment({ content, onDeleteComment }: CommentProps) {
 
   return (
     <div className={styles.comment}>
-      <Avatar hasBorder={false} src="https://github.com/diego3g.png" alt="" />
+      <Avatar
+        hasBorder={false}
+        src="https://github.com/diego3g.png"
+        alt=""
+      />
 
       <div className={styles.commentBox}>
         <div className={styles.commentContent}>


### PR DESCRIPTION
A constante de Post não estava tipada, ocasionando um erro que impossibilitava o projeto.

**New Interface**
```
interface postProps {
  id: number;
  author: {
      avatarUrl: string;
      name: string;
      role: string;
  };
  content: {
      type: "paragraph" | "link";
      content: string;
  }[];
  publishedAt: Date;
}

```

Tipando a constante.